### PR TITLE
chore: pin GitHub Actions and Docker images to digests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '10.0.x'
 
@@ -27,7 +27,7 @@ jobs:
         run: dotnet publish LocalRelay/LocalRelay.csproj --configuration Release -o publish
 
       - name: Upload module artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: OpenShock.LocalRelay.module
           path: publish/OpenShock.LocalRelay.module.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
       contents: write
     steps:
       - name: Download module artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: OpenShock.LocalRelay.module
           path: artifacts/
 
       - name: Create draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
Automated dependency pinning by the HeavenVR maintenance bot:

- GitHub Actions `uses:` refs upgraded to their latest release tag and pinned to the commit SHA that tag resolves to
- Dockerfile `FROM` images pinned to their current `@sha256` digest


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/LocalRelay/pull/19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->