### PR TITLE
chore: stagger dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,16 @@ updates:
     directory: "/"
     schedule:
       interval: 'weekly'
-      day: 'monday'
-      time: '06:00'
+      day: tuesday
+      time: '08:00'
 
   # Check for Nuget package updates
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: 'weekly'
-      day: 'monday'
-      time: '06:00'
+      day: tuesday
+      time: '08:00'
     groups:
       nuget-dependencies:
         patterns:


### PR DESCRIPTION
Automated by the HeavenVR maintenance bot: moves this repo's dependabot update schedule to Tuesday at 08:00, so PRs land spread across the week instead of every repo in the org opening PRs at the same Monday 06:00 slot.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/LocalRelay/pull/20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->